### PR TITLE
Remove duplicate keys (Ruby 2.2 warning)

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -561,7 +561,6 @@ module Bitcoin
       :retarget_interval => 2016,
       :retarget_time => 1209600, # 2 weeks
       :target_spacing    => 600, # block interval
-      :max_money => 21_000_000 * COIN,
       :min_tx_fee => 10_000,
       :min_relay_tx_fee => 10_000,
       :free_tx_bytes => 1_000,
@@ -587,7 +586,6 @@ module Bitcoin
       :retarget_interval => 2016,
       :retarget_time => 1209600, # 2 weeks
       :target_spacing    => 600, # block interval
-      :max_money => 21_000_000 * COIN,
       :min_tx_fee => 10_000,
       :min_relay_tx_fee => 10_000,
       :free_tx_bytes => 1_000,


### PR DESCRIPTION
home/staging/site/shared/bundle/ruby/2.2.0/gems/bitcoin-ruby-0.0.6/lib/bitcoin.rb:553: warning: duplicated key at line 564 ignored: :max_money
/home/staging/site/shared/bundle/ruby/2.2.0/gems/bitcoin-ruby-0.0.6/lib/bitcoin.rb:579: warning: duplicated key at line 590 ignored: :max_money